### PR TITLE
Update grib2 util and graphcastmodel to run both MLGFSand MLGEFS

### DIFF
--- a/oper/run_graphcast_ens.py
+++ b/oper/run_graphcast_ens.py
@@ -29,18 +29,19 @@ from graphcast import rollout
 
 
 class GraphCastModel:
-    def __init__(self, pretrained_model_path, gdas_data_path, gefs_member, config_file, output_dir=None, num_pressure_levels=13, forecast_length=40):
+    def __init__(self, pretrained_model_path, gdas_data_path, case_name, g2prefix, config_file, output_dir=None, num_pressure_levels=13, forecast_length=40):
         self.pretrained_model_path = pretrained_model_path
         self.gdas_data_path = gdas_data_path
         self.forecast_length = forecast_length
         self.num_pressure_levels = num_pressure_levels
-        self.gefs_member = gefs_member
+        self.case_name = case_name
+        self.g2prefix = gg2prefix
         self.config_file_path = config_file
         
         if output_dir is None:
-            self.output_dir = os.path.join(os.getcwd(), f"forecasts_{str(self.num_pressure_levels)}_levels_{self.gefs_member}_model_{int(gefs_member[1:])}")  # Use current directory if not specified
+            self.output_dir = os.getcwd()
         else:
-            self.output_dir = os.path.join(output_dir, f"forecasts_{str(self.num_pressure_levels)}_levels_{self.gefs_member}_model_{int(gefs_member[1:])}")
+            self.output_dir = output_dir
         os.makedirs(self.output_dir, exist_ok=True)
         
         self.params = None
@@ -204,10 +205,10 @@ class GraphCastModel:
         from utils.grib2io import Netcdf2Grib
 
         converter = Netcdf2Grib(self.dates[0][1])
-        converter.save_grib2(ds, self.gefs_member, self.output_dir)
+        converter.save_grib2(ds, self.output_dir, self.g2prefix)
 
         # Call and save forecasts in grib2
-        converter.save_grib2(forecasts, self.gefs_member, self.output_dir)
+        converter.save_grib2(forecasts, self.output_dir, self.g2prefix)
 
         #else:
         #    raise ValueError(f"Method {self.method} is not supported. Choose either 'iris' or 'grib2io'!")
@@ -269,7 +270,8 @@ if __name__ == "__main__":
     parser.add_argument("-i", "--input", help="input file path (including file name)", required=True)
     parser.add_argument("-w", "--weights", help="parent directory of the graphcast params and stats", required=True)
     parser.add_argument("-l", "--length", help="length of forecast (6-hourly), an integer number in range [1, 40]", required=True)
-    parser.add_argument("-m", "--member", help="gefs member [c00, p01, ..., p30]", required=True)
+    parser.add_argument("-m", "--case_name", help="mlgfs, or mlgefs member [c00, p01, ..., p30]", required=True)
+    parser.add_argument("-g", "--g2prefix", help="mlgfs, or mlgefs member [mlgec00, mlgep01, ..., mlgep30]", required=True)
     parser.add_argument("-c", "--config", help="GC weight member file", required=True)
     parser.add_argument("-o", "--output", help="output directory", default=None)
     parser.add_argument("-p", "--pressure", help="number of pressure levels", default=13)

--- a/oper/utils/grib2io.py
+++ b/oper/utils/grib2io.py
@@ -56,7 +56,7 @@ class Netcdf2Grib:
 
         return msg
 
-    def save_grib2(self, xarray_ds, gefs_member, outdir):
+    def save_grib2(self, xarray_ds, outdir, g2prefix):
 
         # Convert geopotential to geopotential height.
         xarray_ds["geopotential"] = xarray_ds["geopotential"] / 9.80665
@@ -81,7 +81,7 @@ class Netcdf2Grib:
             # Set output GRIB2 file.
             cycle = self.start_date.hour
             lead = int(time.dt.total_seconds()//3600)
-            outfile = os.path.join(outdir, f"mlgefs{gefs_member}.t{cycle:02d}z.pgrb2.0p25.f{lead:03d}")
+            outfile = os.path.join(outdir, f"{g2prefix}.t{cycle:02d}z.pgrb2.0p25.f{lead:03d}")
 
             # Delete the old file.
             if os.path.isfile(outfile):
@@ -139,12 +139,12 @@ if __name__ == "__main__":
     
     start_date = pd.to_datetime("2025-07-30 06:00:00")
     ds = xr.open_dataset("forecasts_levels-13_steps-64.nc")
-    gefs_member = "c00"
+    g2prefix = "mlgec00"
 
     t0 = time()
-    outdir = "./forecasts_levels-13"
+    outdir = "./."
     os.makedirs(outdir, exist_ok=True)
     converter = Netcdf2Grib(start_date)
-    converter.save_grib2(ds, gefs_member, outdir)
+    converter.save_grib2(ds, outdir, g2prefix)
 
     print(f"It took {(time()-t0)/60} mins")

--- a/oper/utils/nc2grib.py
+++ b/oper/utils/nc2grib.py
@@ -58,7 +58,7 @@ class Netcdf2Grib:
         yield grib_message
 
     #def save_grib2(self, dates, forecasts, outdir):
-    def save_grib2(self, start_datetime, forecasts, gefs_member, outdir):
+    def save_grib2(self, start_datetime, forecasts, outdir, g2prefix):
         """
         Convert netCDF file to GRIB2 format file.
             Args:
@@ -85,7 +85,7 @@ class Netcdf2Grib:
             forecasts['total_precipitation_cumsum'] = forecasts['total_precipitation_6hr'].cumsum(axis=0)
 
         #filename = os.path.join(outdir, "forecast_to_grib2.nc")
-        filename = os.path.join(outdir, f"forecast_to_grib2_{gefs_member}.nc")
+        filename = os.path.join(outdir, f"forecast_to_grib2_{g2prefix}.nc")
         forecasts.to_netcdf(filename)
 
         # Load cubes from netCDF file
@@ -108,7 +108,7 @@ class Netcdf2Grib:
             print(f"Processing for time {date.strftime('%Y-%m-%d %H:00:00')}")
             hrs = int((date - forecast_starttime).total_seconds() // 3600)
             #outfile = os.path.join(outdir, f'graphcastgfs.t{cycle:02d}z.pgrb2.0p25.f{hrs:03d}')
-            outfile = os.path.join(outdir, f'mlgefs{gefs_member}.t{cycle:02d}z.pgrb2.0p25.f{hrs:03d}')
+            outfile = os.path.join(outdir, f'{g2prefix}.t{cycle:02d}z.pgrb2.0p25.f{hrs:03d}')
             print(outfile)
 
             for cube in sorted(cubes, key=lambda cube: cube.name()):

--- a/oper/wcoss2/jAIGFS_cyclone_track_00.ecf_tmpl
+++ b/oper/wcoss2/jAIGFS_cyclone_track_00.ecf_tmpl
@@ -52,8 +52,8 @@ else
    export COMINgfs=$DATAROOT/mlgefs.$PDY
    pertmember=`echo $pert | cut -c2-3`
    weight=$(expr $pertmember + 0)
-   export ensmember=forecasts_13_levels_{ensemble_member}_model_$weight
-   export fileprefix=mlgefs$pert
+   export ensmember=""
+   export fileprefix=mlge$pert
    export modelname="M"$(echo "$pert" | tr '[:lower:]' '[:upper:]')
 fi
 #model history files

--- a/oper/wcoss2/submit_mlgefs_job_wcoss2.py
+++ b/oper/wcoss2/submit_mlgefs_job_wcoss2.py
@@ -45,7 +45,7 @@ def get_job_id(command):
     return job_id
 
 
-def submit_job_wcoss2(member, param, model_id, curr_datetime, prev_datetime):
+def submit_job_wcoss2(member, param, model_id, curr_datetime, prev_datetime, packagedir):
     ymd=curr_datetime[:8]
     cyc=curr_datetime[8:]
 
@@ -71,15 +71,16 @@ def submit_job_wcoss2(member, param, model_id, curr_datetime, prev_datetime):
     #num_pressure_levels=13
     #forecast_length=64
     model_weights=/lfs/h2/emc/nems/noscrub/jun.wang/mlwp/aiml/gc_weights
-    DATAROOT=/lfs/h2/emc/ptmp/linlin.cui
+    DATAROOT=/lfs/h2/emc/ptmp/$USER
+    PACKAGEDIR=(packagedir} #/lfs/h2/emc/nems/noscrub/linlin.cui/Tests/eagle_ensemble
 
-    cd /lfs/h2/emc/nems/noscrub/linlin.cui/Tests/eagle_ensemble
+    cd {PACKAGEDIR}
 
     # get input data
     python3 gen_gefs_ics.py {prev_datetime} {curr_datetime} {member} -l 13 -s wcoss2 -o $DATAROOT/mlgefs.{ymd}/{cyc} -d $DATAROOT/mlgefs.{ymd}/{cyc}
     
     #get forecasts
-    python3 run_graphcast_ens.py -i $DATAROOT/mlgefs.{ymd}/{cyc}/source-ge{member}_date-{curr_datetime}_res-0.25_levels-13_steps-2.nc -w $model_weights -m "{member}" -c {param} -l 64 -p 13 -o $DATAROOT/mlgefs.{ymd}/{cyc} -u no -k yes 
+    python3 run_graphcast_ens.py -i $DATAROOT/mlgefs.{ymd}/{cyc}/source-ge{member}_date-{curr_datetime}_res-0.25_levels-13_steps-2.nc -w $model_weights -m "{member}" -g "{g2prefix} -c {param} -l 64 -p 13 -o $DATAROOT/mlgefs.{ymd}/{cyc} -u no -k yes 
     """
 
     with tempfile.NamedTemporaryFile(mode="w+", suffix=".pbs", delete=False) as tmpfile:
@@ -109,6 +110,16 @@ def submit_job_wcoss2(member, param, model_id, curr_datetime, prev_datetime):
 
 if __name__ == '__main__':
 
+    #Get current forecast cycle
+    cycles = [0, 6, 12, 18]
+    #now = datetime.datetime(2025, 8, 15, 19, 16)
+    now = None
+    curr_datetime = get_closest_cycle(now=now, cycles=cycles)
+    prev_datetime = curr_datetime - datetime.timedelta(hours=6)
+    print(f'curr_datetime: {curr_datetime}')
+    print(f'prev_datetime: {prev_datetime}')
+
+    #for MLGEFS
     #hostname = socket.gethostname()
     #if hostname.startswith('ufe'):
     #    param_path = '/scratch3/NCEPDEV/nems/Linlin.Cui/Tests/MLGEFSv1.0/oper/graphcast_gefs_params'
@@ -121,20 +132,23 @@ if __name__ == '__main__':
     with open('model_weights.json', 'r') as file:
         models = json.load(file)
 
-    #Get current forecast cycle
-    cycles = [0, 6, 12, 18]
-    #now = datetime.datetime(2025, 8, 15, 19, 16)
-    now = None
-    curr_datetime = get_closest_cycle(now=now, cycles=cycles)
-    prev_datetime = curr_datetime - datetime.timedelta(hours=6)
-    print(f'curr_datetime: {curr_datetime}')
-    print(f'prev_datetime: {prev_datetime}')
-
     for key, values in models.items():
         if key == '0':
             member = f'c{int(key):02d}'
         else:
             member = f'p{int(key):02d}'
 
+        g2prefix = "mlge"+{member}
+
         param = f'{param_path}/{values.get("params")}'
-        submit_job_wcoss2(member, param, key, curr_datetime.strftime("%Y%m%d%H"), prev_datetime.strftime("%Y%m%d%H"))
+        submit_job_wcoss2(member, g2prefix, param, key, curr_datetime.strftime("%Y%m%d%H"), prev_datetime.strftime("%Y%m%d%H"))
+
+    #for MLGFS
+    #param_path='/lfs/h2/emc/nems/noscrub/jun.wang/mlwp/aiml/gc_weights'
+    #param = f'{param_path}/{values.get("params")}'
+    #case_name = "mlgfs"
+    #g2prefix = "mlgfs"
+    #submit_job_wcoss2(case_name, g2prefix, param, key, curr_datetime.strftime("%Y%m%d%H"), prev_datetime.strftime("%Y%m%d%H"))
+
+
+


### PR DESCRIPTION
Changes include:
1) grib2 output name prefix (g2prefix) will be passed from driver script in grib2io.py and nc2grib.py
2) change "gefs_member" to "case_name" in run_graphcast_ens.py and submit_mlgefs_job_wcoss2.py. So the script can run with "mlgfs" for MLGFS, and "c00"... "p30" for MLGEFS. 