### PR TITLE
Drop accumulated total precip for AIGEFS

### DIFF
--- a/oper/utils/grib2writer.py
+++ b/oper/utils/grib2writer.py
@@ -80,12 +80,16 @@ class Grib2Writer:
         # Convert geopotential to geopotential height.
         xarray_ds["geopotential"] = xarray_ds["geopotential"] / 9.80665
 
-        # Update total_precipitation unit to (kg/m^2) and set min to zero
+        # Update total_precipitation_6h unit to (kg/m^2) and set min to zero
         if "total_precipitation_6hr" in xarray_ds:
             xarray_ds["total_precipitation_6hr"] = xarray_ds["total_precipitation_6hr"].clip(min=0) * 1000
 
+        # Drop total_precipitation_cumsum for AIGEFS. Otherwise update unit to (kg/m^2) and set min to zero
         if "total_precipitation_cumsum" in xarray_ds:
-            xarray_ds["total_precipitation_cumsum"] = xarray_ds["total_precipitation_cumsum"].clip(min=0) * 1000
+            if self.case_name.startswith("aige"):
+                xarray_ds = xarray_ds.drop_vars("total_precipitation_cumsum")
+            else:
+                xarray_ds["total_precipitation_cumsum"] = xarray_ds["total_precipitation_cumsum"].clip(min=0) * 1000
 
         # Set min spfh to zero
         if "specific_humidity" in xarray_ds:


### PR DESCRIPTION
This PR dropped accumulated (starting from beginning) total precip for AIGEFS but kept 6-h total precip to be consistent with GEFS. This doesn't affect AIGFS, which still has two APCPs.

AIGEFS for 2025092212:
```
1:0:d=2025092212:UGRD:10 m above ground:384 hour fcst:ENS=+30
2:855178:d=2025092212:VGRD:10 m above ground:384 hour fcst:ENS=+30
3:1708329:d=2025092212:TMP:2 m above ground:384 hour fcst:ENS=+30
4:2200751:d=2025092212:PRMSL:mean sea level:384 hour fcst:ENS=+30
5:3395037:d=2025092212:APCP:surface:378-384 hour acc fcst:ENS=+30
```

AIGFS for 2025092212:
```
1:0:d=2025092212:UGRD:10 m above ground:384 hour fcst:
2:826068:d=2025092212:VGRD:10 m above ground:384 hour fcst:
3:1643380:d=2025092212:TMP:2 m above ground:384 hour fcst:
4:2135325:d=2025092212:PRMSL:mean sea level:384 hour fcst:
5:3310733:d=2025092212:APCP:surface:378-384 hour acc fcst:
6:3629152:d=2025092212:APCP:surface:0-16 day acc fcst:
```

Closes #51 