### PR TITLE
Call ecflow_client to set event for post jobs

### DIFF
--- a/oper/utils/grib2writer.py
+++ b/oper/utils/grib2writer.py
@@ -147,8 +147,8 @@ class Grib2Writer:
 
         # Release post job to create index files and copy files to COM
         if os.environ.get("SENDECF", "NO"):
-            DATA = os.getenv("DATA")
-            cmd = [f"{DATA}/set_event.sh", f"{lead:03d}"]
+            SETEVENTSH = os.environ.get("SETEVENTSH")
+            cmd = [SETEVENTSH, f"{lead:03d}"]
             print(f"Running shell subprocess {cmd}")
             subprocess.run(cmd, check=True)
 

--- a/oper/utils/grib2writer.py
+++ b/oper/utils/grib2writer.py
@@ -146,7 +146,7 @@ class Grib2Writer:
         grib2_out_pres.close()
 
         # Release post job to create index files and copy files to COM
-        if os.getenv("envir") is not None:
+        if os.environ.get("SENDECF", "NO"):
             DATA = os.getenv("DATA")
             cmd = [f"{DATA}/set_event.sh", f"{lead:03d}"]
             print(f"Running shell subprocess {cmd}")

--- a/oper/utils/grib2writer.py
+++ b/oper/utils/grib2writer.py
@@ -145,23 +145,12 @@ class Grib2Writer:
         grib2_out_sfc.close()
         grib2_out_pres.close()
 
-        # Use wgrib2 to generate index files
-        for outfile in [outfile_sfc, outfile_pres]:
-            output_idx_file = f"{outfile}.idx"
-            
-            # Construct the wgrib2 command
-            wgrib2_command = ['wgrib2', '-s', outfile]
-            
-            try:
-                # Open the output file for writing
-                with open(output_idx_file, "w") as f_out:
-                    # Execute the wgrib2 command and redirect stdout to the output file
-                    subprocess.run(wgrib2_command, stdout=f_out, check=True)
-            
-                print(f"Index file created successfully: {output_idx_file}")
-            
-            except subprocess.CalledProcessError as e:
-                print(f"Error running wgrib2 command: {e}")
+        # Release post job to create index files and copy files to COM
+        if os.getenv("envir") is not None:
+            DATA = os.getenv("DATA")
+            cmd = [f"{DATA}/set_event.sh", f"{lead:03d}"]
+            print(f"Running shell subprocess {cmd}")
+            subprocess.run(cmd, check=True)
 
 if __name__ == "__main__":
     


### PR DESCRIPTION
This PR calls `set_event.sh` to trigger post jobs for aigfs (see NOAA-EMC/aigfs#4). Post jobs in in NOAA-EMC/aigfs#4 create grib2 .idx files and copy fiels to COM. This PR replaces NOAA-EMC/MLGlobal#48.

Please note that this solution has already been implemented in para.