### PR TITLE
Add/update NCO bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/nco_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/nco_bug_report.yml
@@ -1,0 +1,66 @@
+name: NCO Bug Report
+description: Report something that is incorrect or broken
+labels: ["nco-bug"]
+type: "bug"
+projects: []
+assignees: []
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Your bug may already be reported!
+        Please search on the [Issue tracker](https://github.com/NOAA-EMC/mlglobal/issues) before creating one.
+
+  - type: textarea
+    id: current_behavior
+    attributes:
+      label: What is wrong?
+      description: Give a brief description of what is incorrect or broken.
+      placeholder: |
+        Short log snippets that illustrate the problem can be included here.
+
+        For any longer logs, please create a GitHub gist (https://gist.github.com/) and link it here.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: What should have happened?
+      placeholder: Describe what you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction_steps
+    attributes:
+      label: Steps to reproduce
+      description: Please give explicit instructions to reproduce the error
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: input
+    id: bugzilla
+    attributes:
+      label: Bugzilla issue
+      description: What is the corresponding NCO bugzilla issue number?
+      placeholder: "#..."
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Additional information
+      description: Provide context or any additional information about the bug.
+
+  - type: textarea
+    id: proposed_implementation
+    attributes:
+      label: Do you have a proposed solution?
+      description: If you already have an idea on how to fix this, please provide it here.
+      placeholder: Optional
+


### PR DESCRIPTION
This PR:
- creates a yaml template form for reporting a bug that is in ops.
- it uses the Github yaml format for creating issues