### PR TITLE
Final adjustments to gen_aig[e]fs_ics.py for production

### DIFF
--- a/oper/gen_aigefs_ics.py
+++ b/oper/gen_aigefs_ics.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 import os
 import sys
 from time import time
@@ -46,14 +45,14 @@ class GFSDataProcessor:
         ).astype(datetime)
 
         #self.s3 = boto3.client('s3')
-        profile_name = os.environ.get('AWS_PROFILE', 'default')
-        session = boto3.Session(profile_name=profile_name)
-        current_credentials = session.get_credentials().get_frozen_credentials()
-        self.s3 = session.client(
-            's3',
-            aws_access_key_id=current_credentials.access_key,
-            aws_secret_access_key=current_credentials.secret_key,
-        )
+        #profile_name = os.environ.get('AWS_PROFILE', 'default')
+        #session = boto3.Session(profile_name=profile_name)
+        #current_credentials = session.get_credentials().get_frozen_credentials()
+        #self.s3 = session.client(
+        #    's3',
+        #    aws_access_key_id=current_credentials.access_key,
+        #    aws_secret_access_key=current_credentials.secret_key,
+        #)
     
         # Specify the S3 bucket name and root directory
         self.bucket_name = 'noaa-ncepdev-none-ca-ufs-cpldcld'
@@ -72,6 +71,8 @@ class GFSDataProcessor:
                 self.bucket_name+'_'+str(self.num_levels)+'_'+self.member_id
             )
 
+        self.local_base_directory = os.path.join(os.getcwd(), "data")
+
         # Specify the output directory where you want to save the processed files
         if self.output_directory is None:
             self.output_directory = os.path.join(os.getcwd(), self.member_id)
@@ -79,7 +80,7 @@ class GFSDataProcessor:
             self.output_directory = os.path.join(self.output_directory, self.member_id)
         os.makedirs(self.output_directory, exist_ok=True)
 
-        self.output_netcdf = os.path.join(self.output_directory, f"aigefs.t{self.cycle:02d}z.ic.nc")
+        self.output_netcdf = os.path.join(self.output_directory, f"mlgefs.t{self.cycle:02d}z.ic.nc")
 
         # List of file formats to download
         if self.num_levels == 13:     
@@ -214,7 +215,7 @@ class GFSDataProcessor:
                         
                     # Extract the specified variables with levels from the GRIB2 file
                     for level in levels:
-                        output_file = os.path.join(self.download_directory,f'{variable}_{level}_{date.hour}{file_extension}_{self.num_levels}_{self.member}.nc')
+                        output_file = f'{variable.replace(":", "")}_{level.replace(":", "")}_{date.hour}{file_extension}_{self.num_levels}_{self.member}.nc'
                         files.append(output_file)
                         
                         # Extracting levels using regular expression
@@ -612,7 +613,7 @@ if __name__ == "__main__":
         keep_downloaded_data
     )
 
-    data_processor.download_data()
+    #data_processor.download_data()
     
     if method == "wgrib2":
       data_processor.process_data_with_wgrib2()

--- a/oper/gen_aigfs_ics.py
+++ b/oper/gen_aigfs_ics.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 '''
 Description
 @uthor: Sadegh Sadeghi Tabas (sadegh.tabas@noaa.gov)
@@ -233,13 +232,15 @@ class GFSDataProcessor:
         files = []
         print("Start extracting variables and associated levels from grib2 files:")
         # Loop through each folder (e.g., gdas.yyyymmdd)
-        date_folders = sorted(next(os.walk(data_directory))[1])
+        #date_folders = sorted(next(os.walk(data_directory))[1])
+        date_folders = [os.path.join(os.path.abspath(os.getenv("DATA")), "data")]
         for date_folder in date_folders:
-            date_folder_path = os.path.join(data_directory, date_folder)
+            #date_folder_path = os.path.join(data_directory, date_folder)
 
             # Loop through each hour (e.g., '00', '06', '12', '18')
             for hour in ['00', '06', '12', '18']:
-                subfolder_path = os.path.join(date_folder_path, hour)
+                #subfolder_path = os.path.join(date_folder_path, hour)
+                subfolder_path = date_folder
 
                 # Check if the subfolder exists before processing
                 if os.path.exists(subfolder_path):
@@ -249,7 +250,8 @@ class GFSDataProcessor:
                             levels = data['levels']
                             first_time_step_only = data.get('first_time_step_only', False)  # Default to False if not specified
 
-                            pattern = os.path.join(subfolder_path, f'gdas.t*z{file_extension}')
+                            #pattern = os.path.join(subfolder_path, f'gdas.t*z{file_extension}')
+                            pattern = os.path.join(subfolder_path, f'gfs.t{hour}z{file_extension}')
                             # Use glob to search for files matching the pattern
                             matching_files = glob.glob(pattern)
                             
@@ -259,10 +261,12 @@ class GFSDataProcessor:
                                 print("Found file:", grib2_file)
                             else:
                                 print("Error: Found multiple or no matching files.")
-                                
+                                continue                                
+
                             # Extract the specified variables with levels from the GRIB2 file
                             for level in levels:
-                                output_file = f'{variable}_{level}_{date_folder}_{hour}{file_extension}_{self.num_levels}.nc'
+                                #output_file = f'{variable}_{level}_{date_folder}_{hour}{file_extension}_{self.num_levels}.nc'
+                                output_file = f'{date_folder}/{variable.replace(":", "")}_{level.replace(":", "")}_{hour}{file_extension}_{self.num_levels}.nc'
                                 files.append(output_file)
                                 
                                 # Extracting levels using regular expression
@@ -656,7 +660,7 @@ if __name__ == "__main__":
     keep_downloaded_data = args.keep.lower() == "yes"
 
     data_processor = GFSDataProcessor(start_datetime, end_datetime, num_pressure_levels, download_source, output_directory, download_directory, keep_downloaded_data)
-    data_processor.download_data()
+    #data_processor.download_data()
     
     if method == "wgrib2":
       data_processor.process_data_with_wgrib2()


### PR DESCRIPTION
This PR includes the last changes that SPA team made to
- `oper/gen_aigfs_ics.py`
- `oper/gen_aigefs_ics.py`

to operationalize the scripts. These changes are a band-aid fix that will need a coordinated fix in the next release. A PR such as #54 would likely resolve these issues. Some key areas we will need to improve on include:
- `oper/gen_aigefs_ics.py`
  - Remove boto initialization (caused failures during testing) and calls to download data from s3 buckets
  - Output netCDF file is still has `mlgefs` prefix, which is consistent with [exaigefs_prep.sh](https://github.com/NOAA-EMC/aigefs/blob/62f3cb50438e13fce5d95ddd3a09301a68ca1214/scripts/exaigefs_prep.sh#L40)
- Both scripts
  - Remove colon characters from intermediate file names
  - Explicitly locate files instead of looping and globbing (#36)