### PR TITLE
update grib2 msg for aigefs

### DIFF
--- a/oper/utils/grib2writer.py
+++ b/oper/utils/grib2writer.py
@@ -136,13 +136,13 @@ class Grib2Writer:
             if "level" in da.coords.keys():
                 for level in da.coords["level"]:
                     msg = self.create_grib2_message(var, da, lead, level=level)
-                    msg.data = da.sel(level=level).values
+                    msg.data = np.squeeze(da.sel(level=level).values)
                     msg.pack()
                     print(f"\t{msg}")
                     grib2_out_pres.write(msg)
             else:
                 msg = self.create_grib2_message(var, da, lead)
-                msg.data = da.values
+                msg.data = np.squeeze(da.values)
                 msg.pack()
                 print(f"\t{msg}")
                 grib2_out_sfc.write(msg)

--- a/oper/utils/grib2writer.py
+++ b/oper/utils/grib2writer.py
@@ -56,12 +56,6 @@ class Grib2Writer:
         if self.case_name.startswith("aige"):
             number = int(self.case_name[-2:])
             msg.perturbationNumber = number
-            if "c00" in self.case_name:
-                msg.typeOfEnsembleForecast = 1
-                msg.typeOfData = 3
-            else:
-                msg.typeOfEnsembleForecast = 3
-                msg.typeOfData = 4
 
         # update decScaleFactor for specific humidity
         # 12 for [5000, 10000]Pa, 10 for [15000, ..., 40000]Pa, 8 for [50000, ..., 100000]Pa


### PR DESCRIPTION
This PR updated `grib2writer.py` to delete resetting attrs `typeOfEnsembleForecast` and `typeOfData` for `AIGEFS`:

```
            if "c00" in self.case_name:
                msg.typeOfEnsembleForecast = 1
                msg.typeOfData = 3
            else:
                msg.typeOfEnsembleForecast = 3
                msg.typeOfData = 4
```

These attributes are updated in the  `tables_aigefs.json` for all members:
```
"typeOfData": 4,
"typeOfEnsembleForecast": 6,
```
And `numberOfEnsembleForecasts` has been changed from 30 to 31:
`"numberOfEnsembleForecasts": 31,`

@RussellManser-NCO Please get the updated json file at: 
`/lfs/h2/emc/nems/noscrub/linlin.cui/Tests/eagle_ensemble/model_weights/tables/tables_aigefs.json`

And `grib2io` package needs to be update to v2.6.0 to incorporate these changes.


